### PR TITLE
feat(plugin): dynamically load librime plugins read from `ibus_rime.yaml`

### DIFF
--- a/rime_engine.c
+++ b/rime_engine.c
@@ -481,9 +481,10 @@ static void ibus_rime_engine_property_activate (IBusEngine *engine,
                                                 guint prop_state)
 {
   extern void ibus_rime_start(gboolean full_check);
+  extern void ibus_rime_stop();
   IBusRimeEngine *rime_engine = (IBusRimeEngine *)engine;
   if (!strcmp("deploy", prop_name)) {
-    rime_api->finalize();
+    ibus_rime_stop();
     ibus_rime_start(TRUE);
     ibus_rime_engine_update(rime_engine);
   }

--- a/rime_main.c
+++ b/rime_main.c
@@ -64,7 +64,7 @@ static void notification_handler(void* context_object,
   }
 }
 
-static int n_plugin_handles;
+static int n_plugin_handles = 0;
 static void **plugin_handles;
 static const char **plugin_modules;
 
@@ -78,20 +78,8 @@ static int load_plugins(const char *config_file)
     return 1;
   }
 
-  RimeConfigIterator iter;
-  int n = 0;
-  if (rime_api->config_begin_list(&iter, &config, "plugins")) {
-    while(rime_api->config_next(&iter)) n++;
-    rime_api->config_end(&iter);
-  }
-
-  int m = 0;
-  if (rime_api->config_begin_list(&iter, &config, "modules")) {
-    while(rime_api->config_next(&iter)) m++;
-    rime_api->config_end(&iter);
-  }
-
   // reserve space new plugins
+  int n = rime_api->config_list_size(&config, "plugins");
   new_plugin_handles = realloc(plugin_handles, sizeof(void *) * (n_plugin_handles + n));
   if (!new_plugin_handles) {
     return 2;
@@ -99,11 +87,13 @@ static int load_plugins(const char *config_file)
     plugin_handles = new_plugin_handles;
   }
 
+  int m = rime_api->config_list_size(&config, "modules");
   plugin_modules = malloc(sizeof(const char *) * (m + 2));
   if (!plugin_modules) {
     return 3;
   }
 
+  RimeConfigIterator iter;
   n = n_plugin_handles;
   if (rime_api->config_begin_list(&iter, &config, "plugins")) {
     while(rime_api->config_next(&iter)) {

--- a/rime_main.c
+++ b/rime_main.c
@@ -227,7 +227,7 @@ static void rime_with_ibus() {
   ibus_rime_start(full_check);
 
   // parse & load plugin modules
-  if (!load_plugins("ibus_rime")) {
+  if (load_plugins("ibus_rime") == 0) {
     // second initialization
     ibus_rime_stop();
     ibus_rime_start(full_check);

--- a/rime_main.c
+++ b/rime_main.c
@@ -174,18 +174,26 @@ void ibus_rime_start(gboolean full_check) {
   RIME_STRUCT(RimeTraits, ibus_rime_traits);
   fill_traits(&ibus_rime_traits);
   ibus_rime_traits.user_data_dir = user_data_dir;
-  if (plugin_modules)
-    ibus_rime_traits.modules = plugin_modules;
 
+  // first initialization
   rime_api->initialize(&ibus_rime_traits);
   if (rime_api->start_maintenance((Bool)full_check)) {
     // update frontend config
     rime_api->deploy_config_file("ibus_rime.yaml", "config_version");
   }
+
+  // parse & load plugin modules
+  if (!load_plugins("ibus_rime")) {
+    rime_api->finalize();
+    // second initialization
+    ibus_rime_traits.modules = plugin_modules;
+    rime_api->initialize(&ibus_rime_traits);
+  }
 }
 
 void ibus_rime_stop() {
   rime_api->finalize();
+  unload_plugins();
 }
 
 static void ibus_disconnect_cb(IBusBus *bus, gpointer user_data) {
@@ -225,20 +233,11 @@ static void rime_with_ibus() {
 
   gboolean full_check = FALSE;
   ibus_rime_start(full_check);
-
-  // parse & load plugin modules
-  if (!load_plugins("ibus_rime")) {
-    // second initialization
-    ibus_rime_stop();
-    ibus_rime_start(full_check);
-  }
-
   ibus_rime_load_settings();
 
   ibus_main();
 
   ibus_rime_stop();
-  unload_plugins();
   notify_uninit();
 
   g_object_unref(factory);

--- a/rime_main.c
+++ b/rime_main.c
@@ -107,6 +107,10 @@ static void load_plugins(RimeConfig *config) {
 
 static void load_modules(RimeConfig *config) {
   int m = rime_api->config_list_size(config, "modules");
+  if (m == 0) {
+    return;
+  }
+
   plugin_modules = malloc(sizeof(const char *) * (m + 2));
   if (!plugin_modules) {
     return;

--- a/rime_main.c
+++ b/rime_main.c
@@ -93,7 +93,7 @@ static int load_plugins(const char *config_file)
 
   // reserve space new plugins
   new_plugin_handles = realloc(plugin_handles, sizeof(void *) * (n_plugin_handles + n));
-  if (new_plugin_handles) {
+  if (!new_plugin_handles) {
     return 2;
   } else {
     plugin_handles = new_plugin_handles;

--- a/rime_main.c
+++ b/rime_main.c
@@ -103,7 +103,6 @@ static void load_plugins(RimeConfig *config) {
     rime_api->config_end(&iter);
   }
   n_plugin_handles = n;
-  printf("n_plugin_handles = %d\n", n);
 }
 
 static void load_modules(RimeConfig *config) {

--- a/rime_main.c
+++ b/rime_main.c
@@ -227,7 +227,7 @@ static void rime_with_ibus() {
   ibus_rime_start(full_check);
 
   // parse & load plugin modules
-  if (load_plugins("ibus_rime") == 0) {
+  if (!load_plugins("ibus_rime")) {
     // second initialization
     ibus_rime_stop();
     ibus_rime_start(full_check);

--- a/rime_main.c
+++ b/rime_main.c
@@ -149,6 +149,14 @@ static void unload_plugins() {
   }
 }
 
+static void fill_traits(RimeTraits *traits) {
+  traits->shared_data_dir = IBUS_RIME_SHARED_DATA_DIR;
+  traits->distribution_name = DISTRIBUTION_NAME;
+  traits->distribution_code_name = DISTRIBUTION_CODE_NAME;
+  traits->distribution_version = DISTRIBUTION_VERSION;
+  traits->app_name = "ibus";
+}
+
 void ibus_rime_start(gboolean full_check) {
   char user_data_dir[512] = {0};
   char old_user_data_dir[512] = {0};
@@ -164,13 +172,8 @@ void ibus_rime_start(gboolean full_check) {
   }
   rime_api->set_notification_handler(notification_handler, NULL);
   RIME_STRUCT(RimeTraits, ibus_rime_traits);
-  ibus_rime_traits.shared_data_dir = IBUS_RIME_SHARED_DATA_DIR;
+  fill_traits(&ibus_rime_traits);
   ibus_rime_traits.user_data_dir = user_data_dir;
-  ibus_rime_traits.distribution_name = DISTRIBUTION_NAME;
-  ibus_rime_traits.distribution_code_name = DISTRIBUTION_CODE_NAME;
-  ibus_rime_traits.distribution_version = DISTRIBUTION_VERSION;
-  ibus_rime_traits.app_name = "ibus";
-  ibus_rime_traits.modules = NULL;
 
   // first initialization
   rime_api->initialize(&ibus_rime_traits);
@@ -223,6 +226,10 @@ static void rime_with_ibus() {
     g_error("notify_init failed");
     exit(1);
   }
+
+  RIME_STRUCT(RimeTraits, ibus_rime_traits);
+  fill_traits(&ibus_rime_traits);
+  rime_api->setup(&ibus_rime_traits);
 
   gboolean full_check = FALSE;
   ibus_rime_start(full_check);


### PR DESCRIPTION
This patch stop loading the hard-coded `librime-legacy` plugin,
instead it reads plugin configuration from `ibus_rime.yaml` and loads plugins at runtime.

The configuration in `ibus_rime.yaml` looks like the following:

```
plugins:
  - librime-legacy.so
  - librime-octagram.so
  - librime-lua.so

modules:
  - legacy
  - grammar
  - lua
```
There are two new sections.
The `plugins` section records files need to be `dlopen()`-ed.
The `modules` section records module names provided by plugins.
(I use "plugin" to represent a unit that can be dynamically loaded,
and "module" to represent a librime module)

---
There are two issues may need to be addressed in the patch.

1. I'm not sure if the "two-sections" configuration is redundant.

   The reason we have to use these two section is that:
    - There is no link between a plugin file name and the module name provided by the file,
      e.g., `librime-octagram` vs `grammar`.
    - In theory a plugin can provide more than one modules.

   It is possible to simplify if we force one-to-one mapping between plugins and their modules,
   i.e., `librime-octagram` <-> `octagram`, `librime-lua` <-> `lua`.


2. librime has to be initialized two times, I'm not sure if it's acceptable.

   The first time is used to parse and read plugin configuration from `ibus_rime.yaml`.
   It seems that there is no API to load modules after initialization,
   so librime has to be initialized the second time.
