### PR TITLE
improve inline_preedit and color_scheme

### DIFF
--- a/rime_engine.c
+++ b/rime_engine.c
@@ -308,6 +308,7 @@ static void ibus_rime_engine_update(IBusRimeEngine *rime_engine)
   gboolean inline_preedit =
       g_ibus_rime_settings.embed_preedit_text && context.commit_text_preview;
   gboolean highlighting =
+      (g_ibus_rime_settings.color_scheme->color_scheme_id != NULL) &&
       (context.composition.sel_start < context.composition.sel_end);
   if (inline_preedit) {
     inline_text = ibus_text_new_from_string(context.commit_text_preview);
@@ -337,7 +338,8 @@ static void ibus_rime_engine_update(IBusRimeEngine *rime_engine)
               inline_text_len));
     }
     else {
-      offset = context.composition.length;  // hide auxiliary text
+        offset = context.composition.sel_start < context.composition.sel_end ?
+            context.composition.sel_start : context.composition.length;  // hide auxiliary text */
     }
   }
   if (offset < context.composition.length) {
@@ -362,12 +364,12 @@ static void ibus_rime_engine_update(IBusRimeEngine *rime_engine)
 
   if (inline_text) {
     ibus_engine_update_preedit_text(
-        (IBusEngine *)rime_engine, inline_text, inline_cursor_pos, TRUE);
+        (IBusEngine *)rime_engine, text, 0, TRUE);
   }
   else {
     ibus_engine_hide_preedit_text((IBusEngine *)rime_engine);
   }
-  if (text) {
+  if (!inline_text && text) {
     ibus_engine_update_auxiliary_text((IBusEngine *)rime_engine, text, TRUE);
   }
   else {

--- a/rime_engine.c
+++ b/rime_engine.c
@@ -362,14 +362,14 @@ static void ibus_rime_engine_update(IBusRimeEngine *rime_engine)
     }
   }
 
-  if (inline_text) {
+  if (inline_preedit) {
     ibus_engine_update_preedit_text(
         (IBusEngine *)rime_engine, text, 0, TRUE);
   }
   else {
     ibus_engine_hide_preedit_text((IBusEngine *)rime_engine);
   }
-  if (!inline_text && text) {
+  if (!inline_preedit && text) {
     ibus_engine_update_auxiliary_text((IBusEngine *)rime_engine, text, TRUE);
   }
   else {

--- a/rime_settings.c
+++ b/rime_settings.c
@@ -6,15 +6,17 @@
 extern RimeApi *rime_api;
 
 static struct ColorSchemeDefinition preset_color_schemes[] = {
-  { NULL, 0, 0 },
+  { RIME_NONE_SCHEME, 0, 0 },
   { "aqua", 0xffffff, 0x0a3dfa },
   { "azure", 0xffffff, 0x0a3dea },
   { "ink", 0xffffff, 0x000000 },
-  { "luna", 0x000000, 0xffff7f }
+  { "luna", 0x000000, 0xffff7f },
+  { NULL, 0, 0 }
 };
 
 static struct IBusRimeSettings ibus_rime_settings_default = {
   FALSE,
+  PREVIEW,
   IBUS_ORIENTATION_SYSTEM,
   &preset_color_schemes[0],
 };
@@ -52,6 +54,12 @@ ibus_rime_load_settings()
   if (rime_api->config_get_bool(
           &config, "style/inline_preedit", &inline_preedit)) {
     g_ibus_rime_settings.embed_preedit_text = !!inline_preedit;
+  }
+
+  const char* preedit_style_str =
+    rime_api->config_get_cstring(&config, "style/preedit_style");
+  if(preedit_style_str && !strcmp(preedit_style_str, "composition")) {
+    g_ibus_rime_settings.preedit_style = COMPOSITION;
   }
 
   Bool horizontal = False;

--- a/rime_settings.c
+++ b/rime_settings.c
@@ -6,11 +6,11 @@
 extern RimeApi *rime_api;
 
 static struct ColorSchemeDefinition preset_color_schemes[] = {
+  { NULL, 0, 0 },
   { "aqua", 0xffffff, 0x0a3dfa },
   { "azure", 0xffffff, 0x0a3dea },
   { "ink", 0xffffff, 0x000000 },
-  { "luna", 0x000000, 0xffff7f },
-  { NULL, 0, 0 }
+  { "luna", 0x000000, 0xffff7f }
 };
 
 static struct IBusRimeSettings ibus_rime_settings_default = {

--- a/rime_settings.h
+++ b/rime_settings.h
@@ -8,6 +8,14 @@
 #define RIME_COLOR_DARK   0x606060
 #define RIME_COLOR_BLACK  0x000000
 
+#define RIME_NONE_SCHEME "NONE"
+
+enum PreeditType
+{
+    COMPOSITION,
+    PREVIEW
+};
+
 struct ColorSchemeDefinition {
   const char* color_scheme_id;
   int text_color;
@@ -16,6 +24,7 @@ struct ColorSchemeDefinition {
 
 struct IBusRimeSettings {
   gboolean embed_preedit_text;
+  gint preedit_style;
   gint lookup_table_orientation;
   struct ColorSchemeDefinition* color_scheme;
 };

--- a/rime_settings.h
+++ b/rime_settings.h
@@ -10,8 +10,7 @@
 
 #define RIME_NONE_SCHEME "NONE"
 
-enum PreeditType
-{
+enum PreeditType {
     COMPOSITION,
     PREVIEW
 };


### PR DESCRIPTION
Let `inline_preedit` be what it should be (aka. `单行模式` in Weasel ), at the same time, do not apply any `color_scheme` when the user has not set it. 

![image](https://user-images.githubusercontent.com/17917040/86764343-8d74b300-c07a-11ea-901d-8684ffad41b9.png)

Related to #82 and #83