### PR TITLE
fix(rime_engine): ignore super modifier in gtk4

### DIFF
--- a/rime_engine.c
+++ b/rime_engine.c
@@ -503,8 +503,8 @@ ibus_rime_engine_process_key_event (IBusEngine *engine,
                                     guint       keycode,
                                     guint       modifiers)
 {
-  // ignore super key
-  if (modifiers & IBUS_SUPER_MASK) {
+  // ignore super key, @see ibus_engine_filter_key_event
+  if (modifiers & (IBUS_SUPER_MASK | IBUS_MOD4_MASK)) {
     return FALSE;
   }
   


### PR DESCRIPTION
Has been fixed in ibus https://github.com/ibus/ibus/commit/7f3bde01636213605e3b9c62d91b8f9b5635b9a6, the gtk4 uses `IBUS_MOD4_MASK` for super key, which breaks the relevent shortcuts in system wide.