### PR TITLE
fix(cmake): call cmake_minimum_required() piror to project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(ibus-rime)
 cmake_minimum_required(VERSION 3.10)
+project(ibus-rime)
 
 set(ibus_rime_version 1.5.1)
 


### PR DESCRIPTION
To fix the cmake warning while building with the command `make ibus-engine-rime`:

```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```