### PR TITLE
fix(rime_engine): Add focus switching processing.

### DIFF
--- a/rime_engine.c
+++ b/rime_engine.c
@@ -201,6 +201,15 @@ ibus_rime_engine_focus_out (IBusEngine *engine)
 static void
 ibus_rime_engine_reset (IBusEngine *engine)
 {
+  IBusRimeEngine *rime_engine = (IBusRimeEngine *)engine;
+
+  if (rime_engine->session_id) {
+    rime_api->clear_composition(rime_engine->session_id);
+    // Clear uncommited contents of the pre-edit buffer.
+    ibus_engine_update_preedit_text_with_mode(
+        engine, ibus_text_new_from_static_string(""), 0, FALSE, IBUS_ENGINE_PREEDIT_CLEAR);
+    ibus_rime_engine_update(rime_engine);
+  }
 }
 
 static void

--- a/rime_main.c
+++ b/rime_main.c
@@ -81,7 +81,9 @@ void ibus_rime_start(gboolean full_check) {
 }
 
 void ibus_rime_stop() {
-  rime_api->finalize();
+  if (rime_api) {
+    rime_api->finalize();
+  }
 }
 
 static void ibus_disconnect_cb(IBusBus *bus, gpointer user_data) {
@@ -134,11 +136,8 @@ static void rime_with_ibus() {
 }
 
 static void sigterm_cb(int sig) {
-  if (rime_api) {
-    ibus_rime_stop();
-  }
-  notify_uninit();
-  exit(EXIT_FAILURE);
+  // Notify the main program to exit.
+  ibus_quit();
 }
 
 int main(gint argc, gchar** argv) {


### PR DESCRIPTION
Clear uncommitted input when focus switches by adding processing for the reset signal.
Fix issues #204 , #141 .

https://github.com/user-attachments/assets/d15e719e-e678-47ad-ab01-74ff9d2483ec

Unify program cleanup operation into the main program. Fixed the issue (#205) where abnormal program exit caused resources to be released multiple times.
