### PR TITLE
allow hide candidate list by rime option _hide_candidate

### DIFF
--- a/rime_engine.c
+++ b/rime_engine.c
@@ -432,7 +432,8 @@ static void ibus_rime_engine_update(IBusRimeEngine *rime_engine)
   }
 
   ibus_lookup_table_clear(rime_engine->table);
-  if (context.menu.num_candidates) {
+  if (context.menu.num_candidates &&
+    !rime_api->get_option(rime_engine->session_id, "_hide_candidate")) {
     int i;
     int num_select_keys =
         context.menu.select_keys ? strlen(context.menu.select_keys) : 0;


### PR DESCRIPTION
This pull request introduces the ability to control whether the candidate list is displayed through a Rime option (_hide_candidate). This feature was originally implemented in [Trime](https://github.com/osfans/trime).

When the option is enabled, Ibus-rime will skip populating and drawing the candidate list, allowing users or schemas to dynamically hide candidates without relying on theme configuration.

Usage Example
```yaml
#in xxx.schema.yaml or xxx.custom.yaml
switches:
  - name: _hide_candidate
    reset: 1
```

1. When _hide_candidate is 1, the candidate list remains empty and the candidate window stays hidden.
2. Default behavior remains unchanged (candidates are shown unless explicitly hidden).
3. No impact on existing configurations.
4. The _hide_candidate option is optional and off by default.
5. Fully compatible with existing themes and styles.
6. With this option, user can dynamic control candidates list by librime-lua script.

The same feature has been merged into Squirrel via [#1073](https://github.com/rime/squirrel/pull/1073)