### PR TITLE
feat(i18n): add gettext support and translation files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(${CMAKE_ROOT}/Modules/FindPkgConfig.cmake)
+
+find_package(Gettext REQUIRED)
+
 pkg_check_modules(IBus REQUIRED ibus-1.0)
 if(IBus_FOUND)
   include_directories(${IBus_INCLUDE_DIRS})
@@ -66,3 +69,25 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rime.xml" DESTINATION "${CMAKE_INSTAL
 install(TARGETS ibus-engine-rime DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/ibus-rime")
 install(DIRECTORY icons DESTINATION "${CMAKE_INSTALL_DATADIR}/ibus-rime" FILES_MATCHING PATTERN "*.png")
 install(FILES ibus_rime.yaml DESTINATION "${RIME_DATA_DIR}")
+
+set(PO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/po")
+file(GLOB PO_FILES CONFIGURE_DEPENDS "${PO_DIR}/*.po")
+set(MO_FILES)
+foreach(PO_FILE ${PO_FILES})
+  get_filename_component(LANG ${PO_FILE} NAME_WE)
+  set(MO_DIR "${CMAKE_CURRENT_BINARY_DIR}/locale/${LANG}/LC_MESSAGES")
+  set(MO_FILE "${MO_DIR}/ibus-rime.mo")
+  add_custom_command( 
+    OUTPUT ${MO_FILE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${MO_DIR}"
+    COMMAND "${MSGFMT_EXECUTABLE}" -o "${MO_FILE}" "${PO_FILE}" DEPENDS "${PO_FILE}"
+    COMMENT "Compiling translation ${LANG}"
+    VERBATIM
+  )
+  list(APPEND MO_FILES "${MO_FILE}")
+  install(FILES "${MO_FILE}" DESTINATION "${CMAKE_INSTALL_LOCALEDIR}/${LANG}/LC_MESSAGES")
+endforeach()
+
+if(MO_FILES)
+  add_custom_target(translations ALL DEPENDS ${MO_FILES})
+endif()

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Refer to https://github.com/rime/home/wiki/RimeWithIBus
 build dependencies:
 
   - pkg-config
+  - gettext
   - cmake>=3.10
   - librime>=1.0 (development package)
   - libibus-1.0 (development package)

--- a/po/message.pot
+++ b/po/message.pot
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the ibus-rime package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy

--- a/po/message.pot
+++ b/po/message.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ibus-rime 1.6.1\n"
+"Report-Msgid-Bugs-To: https://github.com/rime/ibus-rime/issues\n"
+"POT-Creation-Date: 2026-07-28 10:34+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: rime_engine.c:114 rime_engine.c:266
+msgid "Chinese"
+msgstr ""
+
+#: rime_engine.c:126 rime_engine.c:127
+msgid "Deploy"
+msgstr ""
+
+#: rime_engine.c:138
+msgid "Sync"
+msgstr ""
+
+#: rime_engine.c:139
+msgid "Sync data"
+msgstr ""
+
+#: rime_engine.c:253
+msgid "Maintenance"
+msgstr ""
+
+#: rime_main.c:17
+msgid "Rime"
+msgstr ""
+
+#: rime_main.c:42
+msgid "Rime is under maintenance ..."
+msgstr ""
+
+#: rime_main.c:45
+msgid "Rime is ready."
+msgstr ""
+
+#: rime_main.c:49
+msgid "Rime has encountered an error."
+msgstr ""
+
+#: rime_main.c:50
+msgid "See /tmp/rime.ibus.ERROR for details."
+msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,58 @@
+# Chinese translations for ibus-rime package
+# ibus-rime 软件包的简体中文翻译.
+# Copyright (C) 2026 THE ibus-rime'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ibus-rime package.
+# Liang Chenxuan <abcsss2035@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ibus-rime 1.6.1\n"
+"Report-Msgid-Bugs-To: https://github.com/rime/ibus-rime/issues\n"
+"POT-Creation-Date: 2026-07-28 10:34+0800\n"
+"PO-Revision-Date: 2026-07-28 10:37+0800\n"
+"Last-Translator: Liang Chenxuan <abcsss2035@gmail.com>\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: rime_engine.c:114 rime_engine.c:266
+msgid "Chinese"
+msgstr "中文"
+
+#: rime_engine.c:126 rime_engine.c:127
+msgid "Deploy"
+msgstr "部署"
+
+#: rime_engine.c:138
+msgid "Sync"
+msgstr "同步"
+
+#: rime_engine.c:139
+msgid "Sync data"
+msgstr "同步数据"
+
+#: rime_engine.c:253
+msgid "Maintenance"
+msgstr "维护"
+
+#: rime_main.c:17
+msgid "Rime"
+msgstr "Rime"
+
+#: rime_main.c:42
+msgid "Rime is under maintenance ..."
+msgstr "Rime 正在维护中……"
+
+#: rime_main.c:45
+msgid "Rime is ready."
+msgstr "Rime 已就绪。"
+
+#: rime_main.c:49
+msgid "Rime has encountered an error."
+msgstr "Rime 遇到了错误。"
+
+#: rime_main.c:50
+msgid "See /tmp/rime.ibus.ERROR for details."
+msgstr "详情请查看 /tmp/rime.ibus.ERROR。"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -43,7 +43,7 @@ msgstr "Rime"
 
 #: rime_main.c:42
 msgid "Rime is under maintenance ..."
-msgstr "Rime 正在维护中……"
+msgstr "Rime 正在维护……"
 
 #: rime_main.c:45
 msgid "Rime is ready."

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1,0 +1,57 @@
+# Chinese translations for ibus-rime package.
+# Copyright (C) 2026 THE ibus-rime'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ibus-rime package.
+# Liang Chenxuan <abcsss2035@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ibus-rime 1.6.1\n"
+"Report-Msgid-Bugs-To: https://github.com/rime/ibus-rime/issues\n"
+"POT-Creation-Date: 2026-07-28 10:34+0800\n"
+"PO-Revision-Date: 2026-07-28 10:36+0800\n"
+"Last-Translator: Liang Chenxuan <abcsss2035@gmail.com>\n"
+"Language-Team: none\n"
+"Language: zh_HK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: rime_engine.c:114 rime_engine.c:266
+msgid "Chinese"
+msgstr "中文"
+
+#: rime_engine.c:126 rime_engine.c:127
+msgid "Deploy"
+msgstr "部署"
+
+#: rime_engine.c:138
+msgid "Sync"
+msgstr "同步"
+
+#: rime_engine.c:139
+msgid "Sync data"
+msgstr "同步資料"
+
+#: rime_engine.c:253
+msgid "Maintenance"
+msgstr "維護"
+
+#: rime_main.c:17
+msgid "Rime"
+msgstr "Rime"
+
+#: rime_main.c:42
+msgid "Rime is under maintenance ..."
+msgstr "Rime 正在維護中……"
+
+#: rime_main.c:45
+msgid "Rime is ready."
+msgstr "Rime 已準備就緒。"
+
+#: rime_main.c:49
+msgid "Rime has encountered an error."
+msgstr "Rime 遇到錯誤。"
+
+#: rime_main.c:50
+msgid "See /tmp/rime.ibus.ERROR for details."
+msgstr "詳情請查看 /tmp/rime.ibus.ERROR。"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -42,7 +42,7 @@ msgstr "Rime"
 
 #: rime_main.c:42
 msgid "Rime is under maintenance ..."
-msgstr "Rime 正在維護中……"
+msgstr "Rime 正在維護……"
 
 #: rime_main.c:45
 msgid "Rime is ready."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,0 +1,58 @@
+# Chinese translations for ibus-rime package
+# ibus-rime 套件的正體中文翻譯.
+# Copyright (C) 2026 THE ibus-rime'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ibus-rime package.
+# Liang Chenxuan <abcsss2035@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ibus-rime 1.6.1\n"
+"Report-Msgid-Bugs-To: https://github.com/rime/ibus-rime/issues\n"
+"POT-Creation-Date: 2026-07-28 10:34+0800\n"
+"PO-Revision-Date: 2026-07-28 10:37+0800\n"
+"Last-Translator: Liang Chenxuan <abcsss2035@gmail.com>\n"
+"Language-Team: none\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: rime_engine.c:114 rime_engine.c:266
+msgid "Chinese"
+msgstr "中文"
+
+#: rime_engine.c:126 rime_engine.c:127
+msgid "Deploy"
+msgstr "部署"
+
+#: rime_engine.c:138
+msgid "Sync"
+msgstr "同步"
+
+#: rime_engine.c:139
+msgid "Sync data"
+msgstr "同步資料"
+
+#: rime_engine.c:253
+msgid "Maintenance"
+msgstr "維護"
+
+#: rime_main.c:17
+msgid "Rime"
+msgstr "Rime"
+
+#: rime_main.c:42
+msgid "Rime is under maintenance ..."
+msgstr "Rime 正在維護中……"
+
+#: rime_main.c:45
+msgid "Rime is ready."
+msgstr "Rime 已就緒。"
+
+#: rime_main.c:49
+msgid "Rime has encountered an error."
+msgstr "Rime 遇到了錯誤。"
+
+#: rime_main.c:50
+msgid "See /tmp/rime.ibus.ERROR for details."
+msgstr "詳細資訊請查看 /tmp/rime.ibus.ERROR。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -43,7 +43,7 @@ msgstr "Rime"
 
 #: rime_main.c:42
 msgid "Rime is under maintenance ..."
-msgstr "Rime 正在維護中……"
+msgstr "Rime 正在維護……"
 
 #: rime_main.c:45
 msgid "Rime is ready."

--- a/rime_config.h.in
+++ b/rime_config.h.in
@@ -5,5 +5,6 @@
 
 #define IBUS_RIME_ICONS_DIR "@ibus_rime_icons_dir@"
 #define IBUS_RIME_SHARED_DATA_DIR "@RIME_DATA_DIR@"
+#define IBUS_RIME_LOCALEDIR "@CMAKE_INSTALL_FULL_LOCALEDIR@"
 
 #endif  // RIME_CONFIG_H_

--- a/rime_engine.c
+++ b/rime_engine.c
@@ -4,9 +4,6 @@
 #include "rime_engine.h"
 #include "rime_settings.h"
 
-// TODO:
-#define _(x) (x)
-
 extern RimeApi *rime_api;
 
 typedef struct _IBusRimeEngine IBusRimeEngine;
@@ -114,7 +111,7 @@ ibus_rime_engine_init (IBusRimeEngine *rime_engine)
   IBusProperty* prop;
   IBusText* label;
   IBusText* tips;
-  label = ibus_text_new_from_static_string("中文");
+  label = ibus_text_new_from_static_string(_("Chinese"));
   tips = ibus_text_new_from_static_string("中 ↔ A");
   prop = ibus_property_new("InputMode",
                            PROP_TYPE_NORMAL,
@@ -126,7 +123,7 @@ ibus_rime_engine_init (IBusRimeEngine *rime_engine)
                            PROP_STATE_UNCHECKED,
                            NULL);
   ibus_prop_list_append(rime_engine->props, prop);
-  label = ibus_text_new_from_static_string("部署");
+  label = ibus_text_new_from_static_string(_("Deploy"));
   tips = ibus_text_new_from_static_string(_("Deploy"));
   prop = ibus_property_new("deploy",
                            PROP_TYPE_NORMAL,
@@ -138,7 +135,7 @@ ibus_rime_engine_init (IBusRimeEngine *rime_engine)
                            PROP_STATE_UNCHECKED,
                            NULL);
   ibus_prop_list_append(rime_engine->props, prop);
-  label = ibus_text_new_from_static_string("同步");
+  label = ibus_text_new_from_static_string(_("Sync"));
   tips = ibus_text_new_from_static_string(_("Sync data"));
   prop = ibus_property_new("sync",
                            PROP_TYPE_NORMAL,
@@ -253,7 +250,7 @@ static void ibus_rime_update_status(IBusRimeEngine *rime_engine,
   if (prop) {
     if (!status || status->is_disabled) {
       icon = IBUS_RIME_ICONS_DIR "/disabled.png";
-      label = ibus_text_new_from_static_string("維護");
+      label = ibus_text_new_from_static_string(_("Maintenance"));
     }
     else if (status->is_ascii_mode) {
       icon = IBUS_RIME_ICONS_DIR "/abc.png";
@@ -266,7 +263,7 @@ static void ibus_rime_update_status(IBusRimeEngine *rime_engine,
         label = ibus_text_new_from_string(status->schema_name);
       }
       else {
-        label = ibus_text_new_from_static_string("中文");
+        label = ibus_text_new_from_static_string(_("Chinese"));
       }
     }
     if (status && !status->is_disabled && ibus_text_get_length(label) > 0) {

--- a/rime_main.c
+++ b/rime_main.c
@@ -12,9 +12,7 @@
 #include <rime_api.h>
 #include "rime_engine.h"
 #include "rime_settings.h"
-
-// TODO:
-#define _(x) (x)
+#include <locale.h>
 
 #define DISTRIBUTION_NAME _("Rime")
 #define DISTRIBUTION_CODE_NAME "ibus-rime"
@@ -141,6 +139,9 @@ static void sigterm_cb(int sig) {
 }
 
 int main(gint argc, gchar** argv) {
+  setlocale(LC_ALL, "");
+  bindtextdomain(GETTEXT_PACKAGE, IBUS_RIME_LOCALEDIR);
+
   signal(SIGTERM, sigterm_cb);
   signal(SIGINT, sigterm_cb);
 

--- a/rime_settings.h
+++ b/rime_settings.h
@@ -2,6 +2,10 @@
 #define __IBUS_RIME_SETTINGS_H__
 
 #include <ibus.h>
+#include <libintl.h>
+
+#define GETTEXT_PACKAGE "ibus-rime"
+#define _(x) dgettext(GETTEXT_PACKAGE, x)
 
 // colors
 #define RIME_COLOR_LIGHT  0xd4d4d4

--- a/update-po.sh
+++ b/update-po.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 
+if [ -z "$1" ]; then
+    printf "Enter version: "
+    read VERSION
+else
+    VERSION="$1"
+fi
+
+if [ -z "$VERSION" ]; then
+    echo "Version cannot be empty"
+    exit 1
+fi
+
 POT="po/message.pot"
 PO_FILES="po/*.po"
 
 PACKAGE_NAME="ibus-rime"
 BUGS_ADDRESS="https://github.com/rime/ibus-rime/issues"
-VERSION="1.6.1"
 
 xgettext \
     --package-name="$PACKAGE_NAME" \

--- a/update-po.sh
+++ b/update-po.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+POT="po/message.pot"
+PO_FILES="po/*.po"
+
+PACKAGE_NAME="ibus-rime"
+BUGS_ADDRESS="https://github.com/rime/ibus-rime/issues"
+VERSION="1.6.1"
+
+xgettext \
+    --package-name="$PACKAGE_NAME" \
+    --package-version="$VERSION" \
+    --msgid-bugs-address="$BUGS_ADDRESS" \
+    --language=C \
+    --keyword=_ \
+    --output="$POT" \
+    *.c
+
+for po in $PO_FILES; do
+    msgmerge --update "$po" "$POT"
+done


### PR DESCRIPTION
添加 gettext 国际化支持，使通知消息和下拉列表可以根据系统语言显示对应翻译。

- 添加 gettext 初始化与使用。
- 添加翻译文件：
  - 简体中文 (`zh_CN`)
  - 繁体中文（台湾）(`zh_TW`)
  - 繁体中文（香港）(`zh_HK`)
- 添加 CMake 构建规则，自动编译并安装翻译文件。

截图：
<img width="442" height="302" alt="螢幕快照 2026-07-28 12-12-35" src="https://github.com/user-attachments/assets/c3cf981f-8f7e-4ea1-b910-5e1387a746d1" />
<img width="442" height="302" alt="截图 2026-07-28 12-10-51" src="https://github.com/user-attachments/assets/f21d0311-7095-48b5-9d4c-ec18bbcbbf24" />
